### PR TITLE
Fix not ending at correct point after <return>

### DIFF
--- a/plugin/stabs.vim
+++ b/plugin/stabs.vim
@@ -206,8 +206,15 @@ fun! StabsCR()
 		endif
 		return "\<CR>"
 	else
-		return "\<CR>\<c-r>=StabsFixAlign(line('.'))\<CR>\<END>" .
-		       \"\<ESC>:normal!^\<CR>:startinsert\<CR>"
+		let l:ret = "\<CR>\<c-r>=StabsFixAlign(line('.'))\<CR>\<END>"
+		let l:gotobegin = "\<ESC>:normal!^\<CR>:startinsert\<CR>"
+		let l:restofline = getline('.')[(col('.') - 1):]
+		if len(l:restofline) && l:restofline !~ '^\s*$'
+			" goto first nonblank only if <CR> came in middle of
+			" line, ie had something besides whitespace after it
+			let l:ret .= l:gotobegin
+		endif
+		return l:ret
 	endif
 endfun
 

--- a/plugin/stabs.vim
+++ b/plugin/stabs.vim
@@ -206,7 +206,8 @@ fun! StabsCR()
 		endif
 		return "\<CR>"
 	else
-		return "\<CR>\<c-r>=StabsFixAlign(line('.'))\<CR>\<END>"
+		return "\<CR>\<c-r>=StabsFixAlign(line('.'))\<CR>\<END>" .
+		       \"\<ESC>:normal!^\<CR>:startinsert\<CR>"
 	endif
 endfun
 

--- a/plugin/stabs.vim
+++ b/plugin/stabs.vim
@@ -200,6 +200,10 @@ endfun
 " Get the spaces at the end of the indent correct.
 " This is trickier than it should be, but this seems to work.
 fun! StabsCR()
+
+	" For other than normal buffer types, act as a no-op
+	if !empty(getbufvar(bufnr(), '&buftype')) | return "\<CR>" | endif
+
 	if getline('.') =~ s:GetIndentRegex().' *$'
 		if (&cpo !~ 'I') && exists('b:stabs_last_align') && (line('.') == b:stabs_last_align)
 			return "^\<c-d>\<CR>"


### PR DESCRIPTION
After `<CR>` in insert mode, the indent is corrected, but we do not resume insert at the beginning of the corrected line, instead we resume at the end of the line, which is not what we want (for cursor to be positioned exactly where we split the line, but on the new line).  See complaints in #1.  This patch attempts to fix only the `<CR>` case; we still might want to fix other cases later.
